### PR TITLE
Fix gradle 1.5 distribution url

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions-snapshots/gradle-1.5-20130302103424+0000-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.5-bin.zip


### PR DESCRIPTION
It appears that the URL that is currently in the properties file does not exist anymore.  I used the 1.5 release distribution url for gradle in my commit (based on the 1.5 snapshot that was being used before).
